### PR TITLE
Set Redis image tag to 3

### DIFF
--- a/templates/Mailu/1/docker-compose.yml
+++ b/templates/Mailu/1/docker-compose.yml
@@ -3,7 +3,7 @@ services:
  http:
     image: mailu/$FRONTEND:${VERSION}
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -33,8 +33,8 @@ services:
     volumes:
       - "${ROOT}/certs:/certs"
  redis:
-    image: redis:${VERSION}
-    labels: 
+    image: redis:3
+    labels:
      io.rancher.container.pull_image: always
     environment:
      BIND_ADDRESS: ${BIND_ADDRESS}
@@ -60,7 +60,7 @@ services:
       - "${ROOT}/redis:/data"
  imap:
     image: mailu/dovecot:${VERSION}
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -97,7 +97,7 @@ services:
  smtp:
     image: mailu/postfix:${VERSION}
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -129,7 +129,7 @@ services:
       - "${ROOT}/overrides:/overrides"
  milter:
     image: mailu/rmilter:${VERSION}
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     restart: always
     environment:
@@ -159,7 +159,7 @@ services:
  antispam:
     image: mailu/rspamd:${VERSION}
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -186,7 +186,7 @@ services:
  antivirus:
     image: mailu/clamav:${VERSION}
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -213,7 +213,7 @@ services:
  admin:
     image: mailu/admin:${VERSION}
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -245,7 +245,7 @@ services:
  webmail:
     image: "mailu/${WEBMAIL}:${VERSION}"
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -272,7 +272,7 @@ services:
  fetchmail:
     image: mailu/fetchmail:${VERSION}
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -299,7 +299,7 @@ services:
  webdav:
     image: mailu/$WEBDAV:$VERSION
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}


### PR DESCRIPTION
Currently the stack tries to pull the Redis image "matching" the `VERSION` variable.

The default `VERSION` variable value is `stable`, but there is no tag `stable` in the official Redis image.

I'm fixing the tag to the current `latest` equivalent, which is `3` (https://hub.docker.com/_/redis/), in the Rancher Catalog version `v0.0.2` (the one in the folder `1`).

It is a best practice to do not use `latest` as the tag for deployment. As the `latest` tag will have the (future) "latest" version, that could break compatibility with code written for a previous version (current code). So I'm making it be `3`.

If you want, I can update Rancher Catalog version (creating a copy in a `2` directory). But as the current one doesn't work "as is", I thought it would be the place to fix it.