### PR TITLE
Update catalog front end including nginx-no-https

### DIFF
--- a/templates/Mailu/1/docker-compose.yml
+++ b/templates/Mailu/1/docker-compose.yml
@@ -3,7 +3,7 @@ services:
  http:
     image: mailu/$FRONTEND:${VERSION}
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -33,8 +33,8 @@ services:
     volumes:
       - "${ROOT}/certs:/certs"
  redis:
-    image: redis:${VERSION}
-    labels: 
+    image: redis:3
+    labels:
      io.rancher.container.pull_image: always
     environment:
      BIND_ADDRESS: ${BIND_ADDRESS}
@@ -60,7 +60,7 @@ services:
       - "${ROOT}/redis:/data"
  imap:
     image: mailu/dovecot:${VERSION}
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -97,7 +97,7 @@ services:
  smtp:
     image: mailu/postfix:${VERSION}
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -129,7 +129,7 @@ services:
       - "${ROOT}/overrides:/overrides"
  milter:
     image: mailu/rmilter:${VERSION}
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     restart: always
     environment:
@@ -159,7 +159,7 @@ services:
  antispam:
     image: mailu/rspamd:${VERSION}
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -186,7 +186,7 @@ services:
  antivirus:
     image: mailu/clamav:${VERSION}
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -213,7 +213,7 @@ services:
  admin:
     image: mailu/admin:${VERSION}
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -245,7 +245,7 @@ services:
  webmail:
     image: "mailu/${WEBMAIL}:${VERSION}"
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -272,7 +272,7 @@ services:
  fetchmail:
     image: mailu/fetchmail:${VERSION}
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
@@ -299,7 +299,7 @@ services:
  webdav:
     image: mailu/$WEBDAV:$VERSION
     restart: always
-    labels: 
+    labels:
      io.rancher.container.pull_image: always
     environment:
      FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}

--- a/templates/Mailu/2/docker-compose.yml
+++ b/templates/Mailu/2/docker-compose.yml
@@ -1,0 +1,325 @@
+version: '2'
+services:
+ http:
+    image: mailu/$FRONTEND:${VERSION}
+    restart: always
+    labels:
+     io.rancher.container.pull_image: always
+    environment:
+     FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
+     BIND_ADDRESS: ${BIND_ADDRESS}
+     COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+     DEBUG: ${DEBUG}
+     DOMAIN: ${DOMAIN}
+     ENABLE_CERTBOT: ${ENABLE_CERTBOT}
+     EXPOSE_ADMIN: ${EXPOSE_ADMIN}
+     FETCHMAIL_DELAY: ${FETCHMAIL_DELAY}
+     FRONTEND: ${FRONTEND}
+     HOSTNAME: ${HOSTNAME}
+     MESSAGE_SIZE_LIMIT: ${MESSAGE_SIZE_LIMIT}
+     POSTMASTER: ${POSTMASTER}
+     RELAYHOST: ${RELAYHOST}
+     RELAYNETS: ${RELAYNETS}
+     ROOT: ${ROOT}
+     SECRET_KEY: ${SECRET_KEY}
+     VERSION: ${VERSION}
+     WEBMAIL: ${WEBMAIL}
+     LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
+     LETSENCRYPT_HOST: ${VIRTUAL_HOST}
+     VIRTUAL_HOST: ${VIRTUAL_HOST}
+     VIRTUAL_PORT: ${VIRTUAL_PORT}
+     VIRTUAL_PROTO: ${VIRTUAL_PROTO}
+     WEBDAV: ${WEBDAV}
+    volumes:
+      - "${ROOT}/certs:/certs"
+ redis:
+    image: redis:3
+    labels:
+     io.rancher.container.pull_image: always
+    environment:
+     BIND_ADDRESS: ${BIND_ADDRESS}
+     COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+     DEBUG: ${DEBUG}
+     DOMAIN: ${DOMAIN}
+     ENABLE_CERTBOT: ${ENABLE_CERTBOT}
+     EXPOSE_ADMIN: ${EXPOSE_ADMIN}
+     FETCHMAIL_DELAY: ${FETCHMAIL_DELAY}
+     FRONTEND: ${FRONTEND}
+     HOSTNAME: ${HOSTNAME}
+     MESSAGE_SIZE_LIMIT: ${MESSAGE_SIZE_LIMIT}
+     POSTMASTER: ${POSTMASTER}
+     RELAYHOST: ${RELAYHOST}
+     RELAYNETS: ${RELAYNETS}
+     ROOT: ${ROOT}
+     SECRET_KEY: ${SECRET_KEY}
+     VERSION: ${VERSION}
+     WEBMAIL: ${WEBMAIL}
+     WEBDAV: ${WEBDAV}
+    restart: always
+    volumes:
+      - "${ROOT}/redis:/data"
+ imap:
+    image: mailu/dovecot:${VERSION}
+    labels:
+     io.rancher.container.pull_image: always
+    environment:
+     FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
+     BIND_ADDRESS: ${BIND_ADDRESS}
+     COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+     DEBUG: ${DEBUG}
+     DOMAIN: ${DOMAIN}
+     ENABLE_CERTBOT: ${ENABLE_CERTBOT}
+     EXPOSE_ADMIN: ${EXPOSE_ADMIN}
+     FETCHMAIL_DELAY: ${FETCHMAIL_DELAY}
+     FRONTEND: ${FRONTEND}
+     HOSTNAME: ${HOSTNAME}
+     MESSAGE_SIZE_LIMIT: ${MESSAGE_SIZE_LIMIT}
+     POSTMASTER: ${POSTMASTER}
+     RELAYHOST: ${RELAYHOST}
+     RELAYNETS: ${RELAYNETS}
+     ROOT: ${ROOT}
+     SECRET_KEY: ${SECRET_KEY}
+     VERSION: ${VERSION}
+     WEBMAIL: ${WEBMAIL}
+     WEBDAV: ${WEBDAV}
+    restart: always
+    ports:
+      - "${BIND_ADDRESS}:110:110"
+      - "${BIND_ADDRESS}:143:143"
+      - "${BIND_ADDRESS}:993:993"
+      - "${BIND_ADDRESS}:995:995"
+      - "${BIND_ADDRESS}:4190:4190"
+    volumes:
+      - "${ROOT}/data:/data"
+      - "${ROOT}/mail:/mail"
+      - "${ROOT}/certs:/certs"
+      - "${ROOT}/overrides:/overrides"
+ smtp:
+    image: mailu/postfix:${VERSION}
+    restart: always
+    labels:
+     io.rancher.container.pull_image: always
+    environment:
+     FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
+     BIND_ADDRESS: ${BIND_ADDRESS}
+     COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+     DEBUG: ${DEBUG}
+     DOMAIN: ${DOMAIN}
+     ENABLE_CERTBOT: ${ENABLE_CERTBOT}
+     EXPOSE_ADMIN: ${EXPOSE_ADMIN}
+     FETCHMAIL_DELAY: ${FETCHMAIL_DELAY}
+     FRONTEND: ${FRONTEND}
+     HOSTNAME: ${HOSTNAME}
+     MESSAGE_SIZE_LIMIT: ${MESSAGE_SIZE_LIMIT}
+     POSTMASTER: ${POSTMASTER}
+     RELAYHOST: ${RELAYHOST}
+     RELAYNETS: ${RELAYNETS}
+     ROOT: ${ROOT}
+     SECRET_KEY: ${SECRET_KEY}
+     VERSION: ${VERSION}
+     WEBMAIL: ${WEBMAIL}
+     WEBDAV: ${WEBDAV}
+    ports:
+      - "${BIND_ADDRESS}:25:25"
+      - "${BIND_ADDRESS}:465:465"
+      - "${BIND_ADDRESS}:587:587"
+    volumes:
+      - "${ROOT}/data:/data"
+      - "${ROOT}/certs:/certs"
+      - "${ROOT}/overrides:/overrides"
+ milter:
+    image: mailu/rmilter:${VERSION}
+    labels:
+     io.rancher.container.pull_image: always
+    restart: always
+    environment:
+     FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
+     BIND_ADDRESS: ${BIND_ADDRESS}
+     COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+     DEBUG: ${DEBUG}
+     DOMAIN: ${DOMAIN}
+     ENABLE_CERTBOT: ${ENABLE_CERTBOT}
+     EXPOSE_ADMIN: ${EXPOSE_ADMIN}
+     FETCHMAIL_DELAY: ${FETCHMAIL_DELAY}
+     FRONTEND: ${FRONTEND}
+     HOSTNAME: ${HOSTNAME}
+     MESSAGE_SIZE_LIMIT: ${MESSAGE_SIZE_LIMIT}
+     POSTMASTER: ${POSTMASTER}
+     RELAYHOST: ${RELAYHOST}
+     RELAYNETS: ${RELAYNETS}
+     ROOT: ${ROOT}
+     SECRET_KEY: ${SECRET_KEY}
+     VERSION: ${VERSION}
+     WEBMAIL: ${WEBMAIL}
+     WEBDAV: ${WEBDAV}
+    volumes:
+      - "${ROOT}/filter:/data"
+      - "${ROOT}/dkim:/dkim"
+      - "${ROOT}/overrides:/overrides"
+ antispam:
+    image: mailu/rspamd:${VERSION}
+    restart: always
+    labels:
+     io.rancher.container.pull_image: always
+    environment:
+     FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
+     BIND_ADDRESS: ${BIND_ADDRESS}
+     COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+     DEBUG: ${DEBUG}
+     DOMAIN: ${DOMAIN}
+     ENABLE_CERTBOT: ${ENABLE_CERTBOT}
+     EXPOSE_ADMIN: ${EXPOSE_ADMIN}
+     FETCHMAIL_DELAY: ${FETCHMAIL_DELAY}
+     FRONTEND: ${FRONTEND}
+     HOSTNAME: ${HOSTNAME}
+     MESSAGE_SIZE_LIMIT: ${MESSAGE_SIZE_LIMIT}
+     POSTMASTER: ${POSTMASTER}
+     RELAYHOST: ${RELAYHOST}
+     RELAYNETS: ${RELAYNETS}
+     ROOT: ${ROOT}
+     SECRET_KEY: ${SECRET_KEY}
+     VERSION: ${VERSION}
+     WEBMAIL: ${WEBMAIL}
+     WEBDAV: ${WEBDAV}
+    volumes:
+      - "${ROOT}/filter:/var/lib/rspamd"
+ antivirus:
+    image: mailu/clamav:${VERSION}
+    restart: always
+    labels:
+     io.rancher.container.pull_image: always
+    environment:
+     FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
+     BIND_ADDRESS: ${BIND_ADDRESS}
+     COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+     DEBUG: ${DEBUG}
+     DOMAIN: ${DOMAIN}
+     ENABLE_CERTBOT: ${ENABLE_CERTBOT}
+     EXPOSE_ADMIN: ${EXPOSE_ADMIN}
+     FETCHMAIL_DELAY: ${FETCHMAIL_DELAY}
+     FRONTEND: ${FRONTEND}
+     HOSTNAME: ${HOSTNAME}
+     MESSAGE_SIZE_LIMIT: ${MESSAGE_SIZE_LIMIT}
+     POSTMASTER: ${POSTMASTER}
+     RELAYHOST: ${RELAYHOST}
+     RELAYNETS: ${RELAYNETS}
+     ROOT: ${ROOT}
+     SECRET_KEY: ${SECRET_KEY}
+     VERSION: ${VERSION}
+     WEBMAIL: ${WEBMAIL}
+     WEBDAV: ${WEBDAV}
+    volumes:
+      - "${ROOT}/filter:/data"
+ admin:
+    image: mailu/admin:${VERSION}
+    restart: always
+    labels:
+     io.rancher.container.pull_image: always
+    environment:
+     FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
+     BIND_ADDRESS: ${BIND_ADDRESS}
+     COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+     DEBUG: ${DEBUG}
+     DOMAIN: ${DOMAIN}
+     ENABLE_CERTBOT: ${ENABLE_CERTBOT}
+     EXPOSE_ADMIN: ${EXPOSE_ADMIN}
+     FETCHMAIL_DELAY: ${FETCHMAIL_DELAY}
+     FRONTEND: ${FRONTEND}
+     HOSTNAME: ${HOSTNAME}
+     MESSAGE_SIZE_LIMIT: ${MESSAGE_SIZE_LIMIT}
+     POSTMASTER: ${POSTMASTER}
+     RELAYHOST: ${RELAYHOST}
+     RELAYNETS: ${RELAYNETS}
+     ROOT: ${ROOT}
+     SECRET_KEY: ${SECRET_KEY}
+     VERSION: ${VERSION}
+     WEBMAIL: ${WEBMAIL}
+     WEBDAV: ${WEBDAV}
+    ports:
+      - "127.0.0.1:8000:80"
+    volumes:
+      - "${ROOT}/data:/data"
+      - "${ROOT}/dkim:/dkim"
+      - "${ROOT}/certs:/certs"
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+ webmail:
+    image: "mailu/${WEBMAIL}:${VERSION}"
+    restart: always
+    labels:
+     io.rancher.container.pull_image: always
+    environment:
+     FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
+     BIND_ADDRESS: ${BIND_ADDRESS}
+     COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+     DEBUG: ${DEBUG}
+     DOMAIN: ${DOMAIN}
+     ENABLE_CERTBOT: ${ENABLE_CERTBOT}
+     EXPOSE_ADMIN: ${EXPOSE_ADMIN}
+     FETCHMAIL_DELAY: ${FETCHMAIL_DELAY}
+     FRONTEND: ${FRONTEND}
+     HOSTNAME: ${HOSTNAME}
+     MESSAGE_SIZE_LIMIT: ${MESSAGE_SIZE_LIMIT}
+     POSTMASTER: ${POSTMASTER}
+     RELAYHOST: ${RELAYHOST}
+     RELAYNETS: ${RELAYNETS}
+     ROOT: ${ROOT}
+     SECRET_KEY: ${SECRET_KEY}
+     VERSION: ${VERSION}
+     WEBMAIL: ${WEBMAIL}
+     WEBDAV: ${WEBDAV}
+    volumes:
+      - "${ROOT}/webmail:/data"
+ fetchmail:
+    image: mailu/fetchmail:${VERSION}
+    restart: always
+    labels:
+     io.rancher.container.pull_image: always
+    environment:
+     FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
+     BIND_ADDRESS: ${BIND_ADDRESS}
+     COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+     DEBUG: ${DEBUG}
+     DOMAIN: ${DOMAIN}
+     ENABLE_CERTBOT: ${ENABLE_CERTBOT}
+     EXPOSE_ADMIN: ${EXPOSE_ADMIN}
+     FETCHMAIL_DELAY: ${FETCHMAIL_DELAY}
+     FRONTEND: ${FRONTEND}
+     HOSTNAME: ${HOSTNAME}
+     MESSAGE_SIZE_LIMIT: ${MESSAGE_SIZE_LIMIT}
+     POSTMASTER: ${POSTMASTER}
+     RELAYHOST: ${RELAYHOST}
+     RELAYNETS: ${RELAYNETS}
+     ROOT: ${ROOT}
+     SECRET_KEY: ${SECRET_KEY}
+     VERSION: ${VERSION}
+     WEBMAIL: ${WEBMAIL}
+     WEBDAV: ${WEBDAV}
+    volumes:
+      - "${ROOT}/data:/data"
+ webdav:
+    image: mailu/$WEBDAV:$VERSION
+    restart: always
+    labels:
+     io.rancher.container.pull_image: always
+    environment:
+     FETCHMAIL_KEEP: ${FETCHMAIL_KEEP}
+     BIND_ADDRESS: ${BIND_ADDRESS}
+     COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}
+     DEBUG: ${DEBUG}
+     DOMAIN: ${DOMAIN}
+     ENABLE_CERTBOT: ${ENABLE_CERTBOT}
+     EXPOSE_ADMIN: ${EXPOSE_ADMIN}
+     FETCHMAIL_DELAY: ${FETCHMAIL_DELAY}
+     FRONTEND: ${FRONTEND}
+     HOSTNAME: ${HOSTNAME}
+     MESSAGE_SIZE_LIMIT: ${MESSAGE_SIZE_LIMIT}
+     POSTMASTER: ${POSTMASTER}
+     RELAYHOST: ${RELAYHOST}
+     RELAYNETS: ${RELAYNETS}
+     ROOT: ${ROOT}
+     SECRET_KEY: ${SECRET_KEY}
+     VERSION: ${VERSION}
+     WEBMAIL: ${WEBMAIL}
+     WEBDAV: ${WEBDAV}
+    volumes:
+      - "$ROOT/dav:/data"

--- a/templates/Mailu/2/rancher-compose.yml
+++ b/templates/Mailu/2/rancher-compose.yml
@@ -1,0 +1,145 @@
+version: '2'
+.catalog:
+ name: "Supporting Compose v2"
+ minimun_rancher_version: 1.2.0
+ version: "v0.0.3"
+ questions:
+  - variable: VIRTUAL_HOST
+    label: "Mail Server Virtual Host"
+    description: "Input only if you use jwilder/nginx"
+    default: "mail.mailu.io"
+    type: string
+  - variable: VIRTUAL_PORT
+    label: "Mail Server Virtual Port"
+    description: "Input only if you use jwilder/nginx"
+    default: "443"
+    type: string
+  - variable: VIRTUAL_PROTO
+    label: "Mail Server Virtual Proto"
+    description: "Input only if you use jwilder/nginx ( not sure it is usefull )"
+    default: "https"
+    type: string
+  - variable: LETSENCRYPT_EMAIL
+    label: "Lets's Encrypt Email"
+    description: "Input only if you use jwilder/nginx - Email use to create let's encrypt certificate"
+    default: "admin@admin.com"
+    type: string
+  - variable: ROOT
+    label: "Root Path"
+    description: "Set this to the path where Mailu data and configuration is stored"
+    default: "/mailu"
+    required: true
+    type: string
+  - variable: VERSION
+    label: "Mailu Version"
+    description: "Mailu version to run (stable, 1.0, 1.1, etc. or latest)"
+    default: "stable"
+    required: true
+    type: string
+  - variable: SECRET_KEY
+    label: "Mailu Secret Key"
+    description: "Set to a randomly generated 16 bytes string"
+    default: "ChangeMeChangeMe"
+    required: true
+    type: string
+  - variable: BIND_ADDRESS
+    label: "Mailu bind address"
+    description: "Address where listening ports should bind"
+    default: "127.0.0.1"
+    required: true
+    type: string
+  - variable: DOMAIN
+    label: "Main mail domain"
+    default: "mailu.io"
+    required: true
+    type: string
+  - variable: HOSTNAME
+    label: "Exposed mail-server hostname"
+    default: "mail.mailu.io"
+    required: true
+    type: string
+  - variable: POSTMASTER
+    label: "Postmaster"
+    description: "Postmaster local part (will append the main mail domain)"
+    default: "admin"
+    required: true
+    type: string
+  - variable: COMPOSE_PROJECT_NAME
+    label: "Docker-compose project name"
+    description: "Docker-compose project name, this will prepended to containers names."
+    default: "mailu"
+    required: true
+    type: string
+  - variable: FRONTEND
+    label: "Frontend web server"
+    description: "Choose which frontend Web server to run if any (value: nginx, none)"
+    default: "nginx"
+    type: enum
+    options:
+        - "nginx"
+        - "nginx-no-https"
+        - "none"
+  - variable: WEBMAIL
+    label: "Webmail server type"
+    description: "Choose which webmail to run if any (values: roundcube, rainloop, none)"
+    default: "roundcube"
+    type: enum
+    options:
+        - "roundcube"
+        - "rainloop"
+        - "none"
+  - variable: EXPOSE_ADMIN
+    label: "Expose administration"
+    description: "Expose the admin interface in publicly (values: yes, no)"
+    default: "yes"
+    type: enum
+    options:
+        - "yes"
+        - "no"
+  - variable: ENABLE_CERTBOT
+    label: "Use Certbot to generate a TLS cert"
+    description: "Use Letsencrypt to generate a TLS certificate (True to enable)"
+    default: "False"
+    type: enum
+    options:
+        - "True"
+        - "False"
+  - variable: WEBDAV
+    label: "Dav server"
+    description: "Dav server implementation (value: radicale, none)"
+    default: "none"
+    type: enum
+    options:
+        - "none"
+        - "radicale"
+  - variable: MESSAGE_SIZE_LIMIT
+    label: "Message size limit in bytes"
+    description: "Default: accept messages up to 50MB"
+    default: "50000000"
+    type: string
+  - variable: RELAYNETS
+    label: "Networks granted relay permissions"
+    description: "make sure that you include your Docker internal network (default to 172.17.0.0/16)"
+    default: "172.16.0.0/12"
+    type: string
+  - variable: RELAYHOST
+    label: "Host to relay"
+    description: "Will relay all outgoing mails if configured"
+    default: ""
+    type: string
+  - variable: FETCHMAIL_DELAY
+    label: "Fetchmail delay"
+    default: "600"
+    type: string
+  - variable: FETCHMAIL_KEEP
+    label: "Fetchmail keep option"
+    description: "Set this to True when you want to keep the mail on remote server as well"
+    default: "False"
+    type: string
+  - variable: DEBUG
+    label: "Enable Debug"
+    default: "False"
+    type: enum
+    options:
+        - "True"
+        - "False"

--- a/templates/Mailu/config.yml
+++ b/templates/Mailu/config.yml
@@ -1,6 +1,6 @@
 name: Mailu
 description: "Insular email distribution - email server as Docker images"
-version: v0.0.2
+version: v0.0.3
 category: Mail
 maintainer: AdrienM
 license: MIT License


### PR DESCRIPTION
**Note**: This PR depends on https://github.com/Mailu/Mailu/pull/173 being merged.
**Note**: This asumes / includes fixing the Redis image as in the PR: https://github.com/Mailu/Rancher/pull/3.

This creates a new version of the Rancher Catalog template, including an option to chose the `nginx-no-https` frontend.

All the previous functionality keeps untouched, is just an opt-in option.