### PR TITLE
Update docs including nginx-no-https

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,18 @@ To use the **Let's Encrypt** stack to generate the certificates and use them ins
 
 * Create the **Let's Encrypt** stack from the Rancher Catalog [following its documentation](https://github.com/janeczku/rancher-letsencrypt).
 * Enter in the **Let's Encrypt** stack and click the "upgrade" button of the `letsencrypt` service.
-* Go to the "Volumes" tab, it will have a Docker named volume as `letsencrypt:/etc/letsencrypt`.
+* Go to the "Volumes" tab, it will have a Docker named volume as `lets-encrypt:/etc/letsencrypt`.
 * Update that named volume to be a host volume, for example: `/etc/letsencrypt-example.com:/etc/letsencrypt`.
 * Now, after creating the certificates (or renovating them) you will have your certificates as: `fullchain.pem` and `privkey.pem`.
 * Those certificates will be under the path: `/etc/letsencrypt-example.com/production/certs/example.com/`.
 * Now, you have your certificates in your host in that path, but you need them inside the Mailu path, i.e. in: `/mailu/certs/cert.pem` and `/mailu/certs/key.pem`.
-* To achieve that, go to that directory:
+* To achieve that, create the `/mailu/certs/` directory (if you haven't already):
+
+```bash
+mkdir -p /mailu/certs/
+```
+
+* Go to that directory:
 
 ```bash
 cd /mailu/certs/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ ln /etc/letsencrypt-example.com/production/certs/example.com/fullchain.pem cert.
 
 * Now you can start (or re-start) your Mailu Stack.
 
+* As you are using the Rancher Catalog Let's Encrypt stack to generate your certificates, you shouldn't use the integrated certbot with the variable `ENABLE_CERTBOT`, mark it as `False`.
+
+* If you want to use a Rancher Load Balancer to handle HTTPS connections with the certificate generated with the Let's Encrypt stack (working as a TLS / SSL termination proxy) you should choose the alternative frontend that doesn't implement HTTPS itself (giving that task to the Rancher Load Balancer), so instead of `nginx` as frontend, you can use:
+
+```
+nginx-no-https
+```
+
+* Then, to make sure that every `http` request gets redirected to `https` you can start a service (container) that just redirects any `http` to `https`, for example using the Docker image: [`jamessharp/docker-nginx-https-redirect`](https://hub.docker.com/r/jamessharp/docker-nginx-https-redirect/) and configuring routes in your Rancher Load Balancer pointing any `http` to that container so that it gets converted to `https`.
+
 ### Using `jwilder/nginx` and `JrCs/docker-letsencrypt-nginx-proxy-companion`
 
 * If you need jwilder/nginx support and JrCs/docker-letsencrypt-nginx-proxy-companion, you need to manually symlink cert produce by JrCs/docker-letsencrypt-nginx-proxy-companion to `cert.pem` and `key.pem` in ${ROOT}/certs of your Mailu install.


### PR DESCRIPTION
**Note**: this PR depends on https://github.com/Mailu/Rancher/pull/5 being accepted.

Update the documentation including how to use the new optional `nginx-no-https` frontend proposed in https://github.com/Mailu/Mailu/pull/173 and using the new Rancher Catalog template version proposed in: https://github.com/Mailu/Rancher/pull/5

It includes:
* Instructions on how to use the Rancher Catalog Let's Encrypt stack
* How to set up the TLS termination proxy on top of `nginx-no-https` using a Rancher Load Balancer 
* And an alternative on how to set up redirects from HTTP to HTTPS